### PR TITLE
Fixes error when interests is NULL

### DIFF
--- a/R/VisualResume_function.R
+++ b/R/VisualResume_function.R
@@ -828,7 +828,7 @@ if(is.na(timeline$label.x[i])) {
    }
 
 
-   for(interest.i in 1:n.interests) {
+   for(interest.i in seq_len(n.interests)) {
 
      center.x <- locations$x[interest.i]
      center.y <- locations$y[interest.i]


### PR DESCRIPTION
By using seq_len the for loop will not execute when the interests parameter is not used (i.e. set to NULL).